### PR TITLE
Fixed NullReferenceException in NUnit test setup

### DIFF
--- a/KenticoCommunity.StagingConfigurationModule.NetCore.Tests/Extensions/StagingConfigurationStartupExtensionsTests.cs
+++ b/KenticoCommunity.StagingConfigurationModule.NetCore.Tests/Extensions/StagingConfigurationStartupExtensionsTests.cs
@@ -1,0 +1,21 @@
+﻿using KenticoCommunity.StagingConfigurationModule.Extensions;
+using KenticoCommunity.StagingConfigurationModule.Helpers;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using NUnit.Framework;
+
+namespace KenticoCommunity.StagingConfigurationModule.Tests.Extensions
+{
+    [TestFixture]
+    public class StagingConfigurationStartupExtensions
+    {
+
+
+        [Test()]
+        public void AddStagingConfigurationModuleServices_Does_Not_Throw_Exception_When_Configuration_Is_Null()
+        {
+            var serviceCollection = new Mock<IServiceCollection>();
+            Assert.DoesNotThrow(() => serviceCollection.Object.AddStagingConfigurationModuleServices(null));
+        }
+    }
+}

--- a/KenticoCommunity.StagingConfigurationModule/Extensions/StagingConfigurationStartupExtensions.cs
+++ b/KenticoCommunity.StagingConfigurationModule/Extensions/StagingConfigurationStartupExtensions.cs
@@ -42,8 +42,11 @@ namespace KenticoCommunity.StagingConfigurationModule.Extensions
             }
             else
             {
-                services.AddOptions<StagingConfigurationSettings>()
-                    .Bind(configuration.GetSection(configurationKey));
+                if (configuration != null)
+                {
+                    services.AddOptions<StagingConfigurationSettings>()
+                            .Bind(configuration.GetSection(configurationKey));
+                }
                 services.AddSingleton<ISettingsRepository, AppSettingsRepository>();
             }
             services.AddTransient<IConfigurationHelper, ConfigurationHelper>();

--- a/KenticoCommunity.StagingConfigurationModule/KenticoCommunity.StagingConfigurationModule.csproj
+++ b/KenticoCommunity.StagingConfigurationModule/KenticoCommunity.StagingConfigurationModule.csproj
@@ -7,7 +7,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Authors>Kentico Community</Authors>
     <PackageProjectUrl>https://github.com/heywills/StagingConfigurationModule</PackageProjectUrl>
-    <Version>13.0.6</Version>
+    <Version>13.0.7</Version>
     <Description>Simplify Kentico Xperience deployments using this module. It enables configuring the staging feature, so that Kentico objects can be automatically excluded by type, child relationships, and even media libraries.</Description>
     <Copyright>Copyright ©  2021</Copyright>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>


### PR DESCRIPTION
Added null check and unit test, to prevent Xperience Module preinit code from causing unhandled exception during NUnit test setup.